### PR TITLE
change object -> To baseObject, php 7.2

### DIFF
--- a/components/SessionWarningBootstrap.php
+++ b/components/SessionWarningBootstrap.php
@@ -3,16 +3,16 @@
 namespace mgcode\sessionWarning\components;
 
 use \Yii;
+use yii\base\BaseObject;
 use yii\base\BootstrapInterface;
 use yii\base\Event;
-use yii\base\Object;
 use yii\web\Application;
 
 /**
  * @link https://github.com/mg-code/yii2-session-timeout-warning
  * @author Maris Graudins <maris@mg-interactive.lv>
  */
-class SessionWarningBootstrap extends Object implements BootstrapInterface
+class SessionWarningBootstrap extends BaseObject implements BootstrapInterface
 {
     const COOKIE_USER = '__swuid';
     const COOKIE_TIMEOUT = '__swto';


### PR DESCRIPTION
This fix allows the plugin to work with php 7.2 and the latest version of yii2